### PR TITLE
Show clickable IPFS link

### DIFF
--- a/src/Components/BcpPayload.js
+++ b/src/Components/BcpPayload.js
@@ -58,7 +58,22 @@ const BcpPayload = (props) => {
         <>
           {BCP.typeStr(bcp) === 'image' && imagePayload(token, bcp, size)}
           {['audio', 'video'].includes(BCP.typeStr(bcp)) && mediaPayload(bcp)}
-          {BCP.typeStr(bcp) === 'image' && textPayload(bcp)}
+          {BCP.typeStr(bcp) === 'text' && textPayload(bcp)}
+          {BCP.onIPFS(bcp) && (
+            <CardContent>
+              <Typography variant="subtitle2">
+                IPFS Hash:{' '}
+                <a
+                  href={BCP.dataStr(bcp)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  download
+                >
+                  {bcp.data.hash.toString()}
+                </a>
+              </Typography>
+            </CardContent>
+          )}
         </>
       )}
     </>

--- a/src/Components/MediaPayload.js
+++ b/src/Components/MediaPayload.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CardMedia } from '@material-ui/core';
+import { CardMedia, CardContent, Typography } from '@material-ui/core';
 import NFT from '../services/nft.service';
 
 const MediaPayload = (props) => {
@@ -16,6 +16,21 @@ const MediaPayload = (props) => {
             width: `${size}px`,
           }}
         />
+      )}
+      {NFT.onIPFS(token) && (
+        <CardContent>
+          <Typography variant="subtitle2">
+            IPFS:{' '}
+            <a
+              href={NFT.imageURI(token, groups, size)}
+              target="_blank"
+              rel="noopener noreferrer"
+              download
+            >
+              {token.uri}
+            </a>
+          </Typography>
+        </CardContent>
       )}
     </>
   );

--- a/src/services/bcp.service.js
+++ b/src/services/bcp.service.js
@@ -47,5 +47,7 @@ const typeStr = (bcp) => {
   return 'image';
 };
 
+const onIPFS = (bcp) => bcp.source === BCP_SRC_IPFS;
+
 // eslint-disable-next-line import/no-anonymous-default-export
-export default { fromTx, dataStr, typeStr };
+export default { fromTx, dataStr, typeStr, onIPFS };

--- a/src/services/nft.service.js
+++ b/src/services/nft.service.js
@@ -31,5 +31,8 @@ const hasBCP = (token) => {
   return false;
 };
 
+const onIPFS = (token) =>
+  token.uri && (token.uri.startsWith('Qm') || token.uri.startsWith('ipfs://'));
+
 // eslint-disable-next-line import/no-anonymous-default-export
-export default { validGroup, imageURI, hasBCP };
+export default { validGroup, imageURI, hasBCP, onIPFS };


### PR DESCRIPTION
For BCP and NFT cards show clickable link in case the token have payload uploaded to IPFS (document URI)